### PR TITLE
bump varnish and haproxy

### DIFF
--- a/linkto/base.cfg
+++ b/linkto/base.cfg
@@ -221,13 +221,14 @@ output = ${buildout:directory}/etc/nginx.conf
 
 [varnish-config]
 recipe = collective.recipe.template
-input = templates/varnish.vcl.in
+input = templates/varnish_3x.vcl.in
 output = ${buildout:directory}/etc/varnish.vcl
 backend-host = ${bindips:haproxy}
 backend-port = ${ports:haproxy}
 
 [varnish]
 recipe = plone.recipe.varnish
+varnish_version = 3
 daemon = ${buildout:parts-directory}/varnish-build/sbin/varnishd
 config = ${buildout:directory}/etc/varnish.vcl
 bind = ${bindips:varnish}:${ports:varnish}

--- a/linkto/floating_versions.cfg
+++ b/linkto/floating_versions.cfg
@@ -1,6 +1,6 @@
 [download-links]
-varnish = http://repo.varnish-cache.org/source/varnish-2.1.5.tar.gz
-haproxy = http://dist.jarn.com/public/haproxy-1.4.15.zip
+varnish = http://repo.varnish-cache.org/source/varnish-3.0.5.tar.gz
+haproxy = http://dist.jarn.com/public/haproxy-1.4.18.zip
 
 [versions]
 #
@@ -22,7 +22,7 @@ argh = 0.24.1
 collective.backtowork = 0.6.4
 collective.js.jqueryui = 1.10.4
 collective.logbook = 0.6
-collective.recipe.backup = 2.17
+collective.recipe.backup = 2.18
 collective.recipe.grp = 1.1.0
 collective.recipe.omelette = 0.16
 collective.recipe.template = 1.11
@@ -31,28 +31,29 @@ distribute = 0.7.3
 gocept.recipe.env = 1.0
 i18ndude = 3.3.3
 ipdb = 0.8
-ipython = 2.0.0
+ipython = 2.1.0
 iw.debug = 0.3
-meld3 = 0.6.10
+meld3 = 1.0.0
 mr.developer = 1.30
 ordereddict = 1.1
 pathtools = 0.1.2
-plone.app.debugtoolbar = 1.0a2
+plone.app.debugtoolbar = 1.0a3
 plone.recipe.command = 1.1
 plone.recipe.haproxy = 1.1.2
 plone.recipe.precompiler = 0.6
 plone.recipe.varnish = 1.3
 plone.recipe.zope2install = 3.3
-raven = 4.2.1
+raven = 5.0.0
 sauna.reload = 0.5.1
 select-backport = 0.2
-setuptools = 3.4.4
+setuptools = 4.0
 superlance = 0.9
 supervisor = 3.0
 threadframe = 0.2
 watchdog = 0.7.1
 z3c.deadlockdebugger = 0.2
-z3c.jbot = 0.7.1
+z3c.jbot = 0.7.2
+z3c.checkversions = 0.4.2
 z3c.recipe.usercrontab = 1.1
 zc.buildout = 2.2.1
 zc.recipe.cmmi = 1.3.6

--- a/local_production.cfg
+++ b/local_production.cfg
@@ -51,7 +51,7 @@ logdir = ${buildout:vardir}/log
 #    </sentry>
 
 # Only add eggs here that you only want in this environment
-eggs +=
+#eggs +=
 # Longrequest logging
 #    Products.LongRequestLogger[standalone]
 # Sentry logging

--- a/templates/varnish_3x.vcl.in
+++ b/templates/varnish_3x.vcl.in
@@ -1,0 +1,143 @@
+# This file is for varnish 3.x
+# VCL file optimized for plone.app.caching.  See vcl(7) for details
+
+# This is an example of a split view caching setup with another proxy
+# like Apache in front of Varnish to rewrite urls into the VHM style.
+
+# Also assumes a single backend behind Varnish (which could be a single
+# zope instance or a load balancer serving multiple zeo clients).
+# To change this to support multiple backends, see the vcl man pages
+# for instructions.
+
+
+backend default {
+    .host = "${varnish-config:backend-host}";
+    .port = "${varnish-config:backend-port}";
+    .connect_timeout = 0.4s;
+    .first_byte_timeout = 300s;
+    .between_bytes_timeout = 60s;
+}
+
+acl purge {
+    "localhost";
+    "127.0.0.1";
+    "${varnish-config:backend-host}";
+}
+
+sub vcl_recv {
+    set req.grace = 120s;
+    set req.backend = default;
+
+    if (req.request == "PURGE") {
+        if (!client.ip ~ purge) {
+                error 405 "Not allowed.";
+        }
+        ban_url(req.url);
+        error 200 "Purged";
+    }
+    if (req.request != "GET" && req.request != "HEAD") {
+        # We only deal with GET and HEAD by default
+        return(pass);
+    }
+    if (req.http.x-pipe-mark && req.restarts > 0) {
+        return(pipe);
+    }
+    call normalize_accept_encoding;
+    call annotate_request;
+    return(lookup);
+}
+
+sub vcl_fetch {
+    if (beresp.status == 302) {
+        # require_login should not be cached
+        set beresp.http.X-Varnish-Action = "FETCH (pass - redirect)";
+        return(hit_for_pass);
+    }
+    if (!beresp.ttl > 0s) {
+        set beresp.http.X-Varnish-Action = "FETCH (pass - not cacheable)";
+        call save_cache_control_header;
+        return(hit_for_pass);
+    }
+    if (beresp.http.Set-Cookie) {
+        set beresp.http.X-Varnish-Action = "FETCH (pass - response sets cookie)";
+        return(hit_for_pass);
+    }
+    if (!beresp.http.Cache-Control ~ "s-maxage=[1-9]" && beresp.http.Cache-Control ~ "(private|no-cache|no-store)") {
+        set beresp.http.X-Varnish-Action = "FETCH (pass - response sets private/no-cache/no-store token)";
+        return(hit_for_pass);
+    }
+    if (req.http.Authorization && !beresp.http.Cache-Control ~ "public") {
+        set beresp.http.X-Varnish-Action = "FETCH (pass - authorized and no public cache control)";
+        return(hit_for_pass);
+    }
+    if (beresp.http.Content-Length ~ "[0-9]{8,}") {
+        set req.http.x-pipe-mark = "1";
+        return(restart);
+    }
+    if (req.http.X-Anonymous && !beresp.http.Cache-Control) {
+        set beresp.ttl = 600s;
+        set beresp.http.X-Varnish-Action = "FETCH (override - backend not setting cache control)";
+    }
+    call rewrite_s_maxage;
+    return(deliver);
+}
+
+sub vcl_deliver {
+    call restore_cache_control_header;
+    call rewrite_age;
+}
+
+
+##########################
+#  Helper Subroutines
+##########################
+
+# Optimize the Accept-Encoding variant caching
+sub normalize_accept_encoding {
+    if (req.http.Accept-Encoding) {
+        if (req.url ~ "\.(jpe?g|png|gif|swf|pdf|gz|tgz|bz2|tbz|zip|mp3|ogg|mp4|flv)$" || req.url ~ "/image_[^/]*$") {
+            remove req.http.Accept-Encoding;
+        } elsif (req.http.Accept-Encoding ~ "gzip") {
+            set req.http.Accept-Encoding = "gzip";
+        } else {
+            remove req.http.Accept-Encoding;
+        }
+    }
+}
+
+# Keep auth/anon variants apart if "Vary: X-Anonymous" is in the response
+sub annotate_request {
+    if (!(req.http.Authorization || req.http.cookie ~ "(^|.*; )__ac=")) {
+        set req.http.X-Anonymous = "True";
+    }
+}
+
+# The varnish response should always declare itself to be fresh
+sub rewrite_age {
+    if (resp.http.Age) {
+        set resp.http.X-Varnish-Age = resp.http.Age;
+        set resp.http.Age = "0";
+    }
+}
+
+# Rewrite s-maxage to exclude from intermediary proxies
+# (to cache *everywhere*, just use 'max-age' token in the response to avoid this override)
+sub rewrite_s_maxage {
+    if (beresp.http.Cache-Control ~ "s-maxage") {
+        set beresp.http.Cache-Control = regsub(beresp.http.Cache-Control, "s-maxage=[0-9]+", "s-maxage=0");
+    }
+}
+
+# Save the Cache-Control header
+sub save_cache_control_header {
+    set beresp.http.X-Propagate-Cache-Control = beresp.http.Cache-Control;
+}
+
+# Restore the Cache-Control header
+sub restore_cache_control_header {
+    if (resp.http.X-Propagate-Cache-Control) {
+        set resp.http.Cache-Control = resp.http.X-Propagate-Cache-Control;
+        unset resp.http.X-Propagate-Cache-Control;
+    }
+}
+


### PR DESCRIPTION
bump varnish from 2.1.5 to 3.0.5 (2.x is unsupported) and haproxy from 1.4.15 to 1.4.18
varnish now has a new config-file since the syntax changed
files larger than 10MB are no longer cached
