### PR TITLE
Fix missing glyph font in production resource bundle

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -17,7 +17,7 @@ server {
        add_header X-Frame-Options SAMEORIGIN;
        add_header X-Content-Type-Options nosniff;
        add_header X-XSS-Protection "1; mode=block";
-       add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ssl.google-analytics.com  https://connect.facebook.net https://maps.googleapis.com https://maps.gstatic.com; img-src 'self' https://ssl.google-analytics.com https://s-static.ak.facebook.com https://assets.zendesk.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://themes.googleusercontent.com; frame-src 'self' https://www.facebook.com https://s-static.ak.facebook.com; object-src 'none'";
+       add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ssl.google-analytics.com  https://connect.facebook.net https://maps.googleapis.com https://maps.gstatic.com; img-src 'self' https://ssl.google-analytics.com https://s-static.ak.facebook.com https://assets.zendesk.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://themes.googleusercontent.com; frame-src 'self' https://www.facebook.com https://s-static.ak.facebook.com; object-src 'none'";
 
        location / {
           proxy_pass http://varnish_production_${buildout:site}_www/VirtualHostBase/http/www.${buildout:domainname}.de:80/${buildout:plone_site_name}/VirtualHostRoot/;


### PR DESCRIPTION
The production buildout will inline the glyph font used in Barceloneta with a data: base64. So browsing through nginx will break many icons like document-type icons and the site setup dashboard.