### PR TITLE
Fix not generated plone-compile-resources scripts

### DIFF
--- a/local_develop.cfg
+++ b/local_develop.cfg
@@ -119,6 +119,7 @@ packages = ${instance:location}/lib/python ./
 [zopepy]
 recipe = zc.recipe.egg
 eggs = ${buildout:eggs}
+       plone.staticresources
 interpreter = zopepy
 
 [checkversions]


### PR DESCRIPTION
The scripts are moved here: https://github.com/plone/plone.staticresources/tree/master/src/plone/staticresources/_scripts

